### PR TITLE
AdapterBuilder

### DIFF
--- a/SpaceBattle.Lib.Tests/AdapterBuilderTest.cs
+++ b/SpaceBattle.Lib.Tests/AdapterBuilderTest.cs
@@ -86,7 +86,7 @@ public class AdapterBuilderTest
         var adapterCode = IoC.Resolve<string>("Game.Adapter.Build", typeof(IMovable), typeof(IUObject));
         var assembly = CompileAdapter(adapterCode);
         var adapterType = assembly.GetTypes().First(t => t.Name == "IMovableAdapter");
-        var adapter = Activator.CreateInstance(adapterType, new Mock<IUObject>().Object) as IMovable 
+        var adapter = Activator.CreateInstance(adapterType, new Mock<IUObject>().Object) as IMovable
             ?? throw new InvalidOperationException("Failed to create adapter");
 
         var moveCommand = new MoveCommand(adapter);
@@ -96,7 +96,6 @@ public class AdapterBuilderTest
         Assert.Equal(expectedNewPosition, actualNewPosition);
     }
 
-
     private static Assembly CompileAdapter(string code)
     {
         var systemRuntime = typeof(object).Assembly.Location;
@@ -105,7 +104,7 @@ public class AdapterBuilderTest
         var vectorAssembly = typeof(Vector).Assembly.Location;
         var hwdtechAssembly = typeof(Hwdtech.IoC).Assembly.Location;
         var movableAssembly = typeof(IMovable).Assembly.Location;
-        
+
         var references = new[]
         {
         MetadataReference.CreateFromFile(systemRuntime),

--- a/SpaceBattle.Lib.Tests/AdapterBuilderTest.cs
+++ b/SpaceBattle.Lib.Tests/AdapterBuilderTest.cs
@@ -15,37 +15,21 @@ public class AdapterBuilderTest
     [Fact]
     public void PositiveBuildingAdapter()
     {
-        var expected =
-@"public class IMovableAdapter : IMovable
-{
-    readonly private IUObject _obj;
-    public IMovableAdapter(IUObject obj) => _obj = obj;
-
-    public Vector Position
-    {
-
-        get => IoC.Resolve<Vector>(""Game.Get.Property"", ""Position"", _obj);
-
-
-        set => IoC.Resolve<ICommand>(""Game.Set.Property"", ""Position"", _obj, value).Execute();
-
-    }
-
-    public Vector Velocity
-    {
-
-        get => IoC.Resolve<Vector>(""Game.Get.Property"", ""Velocity"", _obj);
-
-
-    }
-
-}";
         new AdapterBuilder().Builder();
         var targetType = typeof(IUObject);
         var newTargetType = typeof(IMovable);
 
         var result = IoC.Resolve<string>("Game.Adapter.Build", newTargetType, targetType);
 
-        Assert.Equal(expected, result);
+        Assert.Contains("public class IMovableAdapter : IMovable", result);
+        Assert.Contains("readonly private IUObject _obj;", result);
+        Assert.Contains("public IMovableAdapter(IUObject obj) => _obj = obj;", result);
+
+        Assert.Contains("public Vector Position", result);
+        Assert.Contains("get => IoC.Resolve<Vector>(\"Game.Get.Property\", \"Position\", _obj);", result);
+        Assert.Contains("set => IoC.Resolve<ICommand>(\"Game.Set.Property\", \"Position\", _obj, value).Execute();", result);
+
+        Assert.Contains("public Vector Velocity", result);
+        Assert.Contains("get => IoC.Resolve<Vector>(\"Game.Get.Property\", \"Velocity\", _obj);", result);
     }
 }

--- a/SpaceBattle.Lib.Tests/AdapterBuilderTest.cs
+++ b/SpaceBattle.Lib.Tests/AdapterBuilderTest.cs
@@ -1,5 +1,8 @@
 ﻿using Hwdtech;
 using Hwdtech.Ioc;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace SpaceBattle.Lib.Tests;
 
@@ -9,27 +12,33 @@ public class AdapterBuilderTest
     {
         new InitScopeBasedIoCImplementationCommand().Execute();
         IoC.Resolve<Hwdtech.ICommand>("Scopes.Current.Set",
-        IoC.Resolve<object>("Scopes.New", IoC.Resolve<object>("Scopes.Root"))).Execute();
+            IoC.Resolve<object>("Scopes.New", IoC.Resolve<object>("Scopes.Root"))).Execute();
     }
-
     [Fact]
     public void PositiveBuildingAdapter()
     {
-        new AdapterBuilder().Builder();
+        var builder = new AdapterBuilder();
+        builder.Builder();
+
         var targetType = typeof(IUObject);
         var newTargetType = typeof(IMovable);
 
-        var result = IoC.Resolve<string>("Game.Adapter.Build", newTargetType, targetType);
+        var generatedCode = IoC.Resolve<string>("Game.Adapter.Build", newTargetType, targetType);
+        var syntaxTree = CSharpSyntaxTree.ParseText(generatedCode);
 
-        Assert.Contains("public class IMovableAdapter : IMovable", result);
-        Assert.Contains("readonly private IUObject _obj;", result);
-        Assert.Contains("public IMovableAdapter(IUObject obj) => _obj = obj;", result);
+        var diagnostics = syntaxTree.GetDiagnostics();
+        Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
 
-        Assert.Contains("public Vector Position", result);
-        Assert.Contains("get => IoC.Resolve<Vector>(\"Game.Get.Property\", \"Position\", _obj);", result);
-        Assert.Contains("set => IoC.Resolve<ICommand>(\"Game.Set.Property\", \"Position\", _obj, value).Execute();", result);
+        var root = syntaxTree.GetRoot();
 
-        Assert.Contains("public Vector Velocity", result);
-        Assert.Contains("get => IoC.Resolve<Vector>(\"Game.Get.Property\", \"Velocity\", _obj);", result);
+        var classDeclarations = root.DescendantNodes().OfType<ClassDeclarationSyntax>();
+        Assert.Contains(classDeclarations, cd => cd.Identifier.Text == "IMovableAdapter");
+
+        var constructors = root.DescendantNodes().OfType<ConstructorDeclarationSyntax>();
+        Assert.Contains(constructors, c => c.ParameterList.Parameters.Count == 1);
+
+        var properties = root.DescendantNodes().OfType<PropertyDeclarationSyntax>();
+        Assert.Contains(properties, p => p.Identifier.Text == "Position");
+        Assert.Contains(properties, p => p.Identifier.Text == "Velocity");
     }
 }

--- a/SpaceBattle.Lib.Tests/AdapterBuilderTest.cs
+++ b/SpaceBattle.Lib.Tests/AdapterBuilderTest.cs
@@ -1,47 +1,22 @@
-using Hwdtech;
+﻿using Hwdtech;
 using Hwdtech.Ioc;
 
 namespace SpaceBattle.Lib.Tests;
 
 public class AdapterBuilderTest
 {
-    private readonly string _template;
     public AdapterBuilderTest()
     {
-            new InitScopeBasedIoCImplementationCommand().Execute();
-            IoC.Resolve<Hwdtech.ICommand>("Scopes.Current.Set", 
-            IoC.Resolve<object>("Scopes.New", IoC.Resolve<object>("Scopes.Root"))).Execute();
-
-                "IoC.Register",
-                "Template",
-                (object[] args) => _template
-            ).Execute();
-
-            _template = 
-@"public class {{new_target_type}}Adapter : {{new_target_type}}
-{
-    readonly private {{target_type}} _obj;
-    public {{new_target_type}}Adapter({{target_type}} obj) => _obj = obj;
-{{for property in properties}}
-    public {{property.property_type.name}} {{property.name}}
-    {
-{{if property.can_read}}
-        get => IoC.Resolve<{{property.property_type.name}}>(""Game.Get.Property"", ""{{property.name}}"", _obj);
-{{end}}
-{{if property.can_write}}
-        set => IoC.Resolve<ICommand>(""Game.Set.Property"", ""{{property.name}}"", _obj, value).Execute();
-{{end}}
-    }
-{{end}}
-}";
-
+        new InitScopeBasedIoCImplementationCommand().Execute();
+        IoC.Resolve<Hwdtech.ICommand>("Scopes.Current.Set",
+        IoC.Resolve<object>("Scopes.New", IoC.Resolve<object>("Scopes.Root"))).Execute();
     }
 
     [Fact]
     public void PositiveBuildingAdapter()
     {
-         var expected =
- @"public class IMovableAdapter : IMovable
+        var expected =
+@"public class IMovableAdapter : IMovable
 {
     readonly private IUObject _obj;
     public IMovableAdapter(IUObject obj) => _obj = obj;
@@ -65,14 +40,12 @@ public class AdapterBuilderTest
     }
 
 }";
+        new AdapterBuilder().Builder();
+        var targetType = typeof(IUObject);
+        var newTargetType = typeof(IMovable);
 
-            var builder = new AdapterBuilder(
-                targetType: typeof(IUObject),
-                newTargetType: typeof(IMovable)
-            );
+        var result = IoC.Resolve<string>("Game.Adapter.Build", newTargetType, targetType);
 
-            var result = builder.Build().ReplaceLineEndings();
-
-            Assert.Equal(expected, result);
+        Assert.Equal(expected, result);
     }
 }

--- a/SpaceBattle.Lib.Tests/AdapterBuilderTest.cs
+++ b/SpaceBattle.Lib.Tests/AdapterBuilderTest.cs
@@ -1,8 +1,10 @@
-﻿using Hwdtech;
+﻿using System.Reflection;
+using Hwdtech;
 using Hwdtech.Ioc;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Moq;
 
 namespace SpaceBattle.Lib.Tests;
 
@@ -14,6 +16,7 @@ public class AdapterBuilderTest
         IoC.Resolve<Hwdtech.ICommand>("Scopes.Current.Set",
             IoC.Resolve<object>("Scopes.New", IoC.Resolve<object>("Scopes.Root"))).Execute();
     }
+
     [Fact]
     public void PositiveBuildingAdapter()
     {
@@ -40,5 +43,98 @@ public class AdapterBuilderTest
         var properties = root.DescendantNodes().OfType<PropertyDeclarationSyntax>();
         Assert.Contains(properties, p => p.Identifier.Text == "Position");
         Assert.Contains(properties, p => p.Identifier.Text == "Velocity");
+    }
+
+    [Fact]
+    public void Adapter_ShouldCorrectlyWork()
+    {
+        new AdapterBuilder().Builder();
+
+        var initialPosition = new Vector(new int[] { 12, 5 });
+        var velocity = new Vector(new int[] { -7, 3 });
+        var expectedNewPosition = initialPosition + velocity;
+
+        IoC.Resolve<Hwdtech.ICommand>("IoC.Register", "Game.Get.Property", (object[] args) =>
+        {
+            var propertyName = args[0];
+            var obj = args[1];
+
+            return propertyName switch
+            {
+                "Position" => initialPosition,
+                "Velocity" => velocity,
+                _ => throw new Exception($"Unknown property: {propertyName}")
+            };
+        }).Execute();
+
+        var setPropertyCalled = false;
+        var actualNewPosition = new Vector(new int[] { 0, 0 });
+
+        IoC.Resolve<Hwdtech.ICommand>("IoC.Register", "Game.Set.Property", (object[] args) =>
+        {
+            var propertyName = args[0];
+            var obj = args[1];
+            var value = (Vector)args[2];
+
+            return new ActionCommand(() =>
+            {
+                setPropertyCalled = true;
+                actualNewPosition = value;
+            });
+        }).Execute();
+
+        var adapterCode = IoC.Resolve<string>("Game.Adapter.Build", typeof(IMovable), typeof(IUObject));
+        var assembly = CompileAdapter(adapterCode);
+        var adapterType = assembly.GetTypes().First(t => t.Name == "IMovableAdapter");
+        var adapter = Activator.CreateInstance(adapterType, new Mock<IUObject>().Object) as IMovable 
+            ?? throw new InvalidOperationException("Failed to create adapter");
+
+        var moveCommand = new MoveCommand(adapter);
+        moveCommand.Execute();
+
+        Assert.True(setPropertyCalled, "Команда MoveCommand не выполнила SetProperty");
+        Assert.Equal(expectedNewPosition, actualNewPosition);
+    }
+
+
+    private static Assembly CompileAdapter(string code)
+    {
+        var systemRuntime = typeof(object).Assembly.Location;
+        var iobjectAssembly = typeof(IUObject).Assembly.Location;
+        var commandAssembly = typeof(ICommand).Assembly.Location;
+        var vectorAssembly = typeof(Vector).Assembly.Location;
+        var hwdtechAssembly = typeof(Hwdtech.IoC).Assembly.Location;
+        var movableAssembly = typeof(IMovable).Assembly.Location;
+        
+        var references = new[]
+        {
+        MetadataReference.CreateFromFile(systemRuntime),
+        MetadataReference.CreateFromFile(iobjectAssembly),
+        MetadataReference.CreateFromFile(commandAssembly),
+        MetadataReference.CreateFromFile(vectorAssembly),
+        MetadataReference.CreateFromFile(hwdtechAssembly),
+        MetadataReference.CreateFromFile(movableAssembly),
+        MetadataReference.CreateFromFile(Assembly.Load("System.Runtime").Location),
+        MetadataReference.CreateFromFile(Assembly.Load("netstandard").Location),
+        MetadataReference.CreateFromFile(Assembly.LoadFrom("SpaceBattle.Lib.Tests.dll").Location)
+    };
+
+        var fullCode = @"
+using System;
+using Hwdtech;
+using static Hwdtech.IoC;
+namespace SpaceBattle.Lib.Test;
+" + code;
+
+        var compilation = CSharpCompilation.Create(
+            "TempAdapterAssembly",
+            new[] { CSharpSyntaxTree.ParseText(fullCode) },
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        using var ms = new MemoryStream();
+        var result = compilation.Emit(ms);
+        ms.Seek(0, SeekOrigin.Begin);
+        return Assembly.Load(ms.ToArray());
     }
 }

--- a/SpaceBattle.Lib.Tests/AdapterBuilderTest.cs
+++ b/SpaceBattle.Lib.Tests/AdapterBuilderTest.cs
@@ -1,0 +1,78 @@
+using Hwdtech;
+using Hwdtech.Ioc;
+
+namespace SpaceBattle.Lib.Tests;
+
+public class AdapterBuilderTest
+{
+    private readonly string _template;
+    public AdapterBuilderTest()
+    {
+            new InitScopeBasedIoCImplementationCommand().Execute();
+            IoC.Resolve<Hwdtech.ICommand>("Scopes.Current.Set", 
+            IoC.Resolve<object>("Scopes.New", IoC.Resolve<object>("Scopes.Root"))).Execute();
+
+                "IoC.Register",
+                "Template",
+                (object[] args) => _template
+            ).Execute();
+
+            _template = 
+@"public class {{new_target_type}}Adapter : {{new_target_type}}
+{
+    readonly private {{target_type}} _obj;
+    public {{new_target_type}}Adapter({{target_type}} obj) => _obj = obj;
+{{for property in properties}}
+    public {{property.property_type.name}} {{property.name}}
+    {
+{{if property.can_read}}
+        get => IoC.Resolve<{{property.property_type.name}}>(""Game.Get.Property"", ""{{property.name}}"", _obj);
+{{end}}
+{{if property.can_write}}
+        set => IoC.Resolve<ICommand>(""Game.Set.Property"", ""{{property.name}}"", _obj, value).Execute();
+{{end}}
+    }
+{{end}}
+}";
+
+    }
+
+    [Fact]
+    public void PositiveBuildingAdapter()
+    {
+         var expected =
+ @"public class IMovableAdapter : IMovable
+{
+    readonly private IUObject _obj;
+    public IMovableAdapter(IUObject obj) => _obj = obj;
+
+    public Vector Position
+    {
+
+        get => IoC.Resolve<Vector>(""Game.Get.Property"", ""Position"", _obj);
+
+
+        set => IoC.Resolve<ICommand>(""Game.Set.Property"", ""Position"", _obj, value).Execute();
+
+    }
+
+    public Vector Velocity
+    {
+
+        get => IoC.Resolve<Vector>(""Game.Get.Property"", ""Velocity"", _obj);
+
+
+    }
+
+}";
+
+            var builder = new AdapterBuilder(
+                targetType: typeof(IUObject),
+                newTargetType: typeof(IMovable)
+            );
+
+            var result = builder.Build().ReplaceLineEndings();
+
+            Assert.Equal(expected, result);
+    }
+}

--- a/SpaceBattle.Lib.Tests/SpaceBattle.Lib.Tests.csproj
+++ b/SpaceBattle.Lib.Tests/SpaceBattle.Lib.Tests.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Hwdtech.Ioc.ScopeBasedIoCImplementation" Version="1.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="Moq" Version="4.20.70" />
-    <PackageReference Include="Scriban" Version="5.12.1" />
+    <PackageReference Include="Scriban" Version="6.0.0" />
     <PackageReference Include="SpecFlow.xUnit" Version="3.9.74" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/SpaceBattle.Lib.Tests/SpaceBattle.Lib.Tests.csproj
+++ b/SpaceBattle.Lib.Tests/SpaceBattle.Lib.Tests.csproj
@@ -15,6 +15,7 @@
     </PackageReference>
     <PackageReference Include="Hwdtech.IoC" Version="1.0.0" />
     <PackageReference Include="Hwdtech.Ioc.ScopeBasedIoCImplementation" Version="1.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="4.13.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="Scriban" Version="6.0.0" />

--- a/SpaceBattle.Lib.Tests/SpaceBattle.Lib.Tests.csproj
+++ b/SpaceBattle.Lib.Tests/SpaceBattle.Lib.Tests.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="Hwdtech.Ioc.ScopeBasedIoCImplementation" Version="1.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="Moq" Version="4.20.70" />
+    <PackageReference Include="Scriban" Version="5.12.1" />
     <PackageReference Include="SpecFlow.xUnit" Version="3.9.74" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/SpaceBattle.Lib/AdapterBuilder.cs
+++ b/SpaceBattle.Lib/AdapterBuilder.cs
@@ -1,43 +1,50 @@
-using Hwdtech;
+﻿using Hwdtech;
 using Scriban;
 
 public class AdapterBuilder
 {
-    private readonly Type _targetType;
-    private readonly Type _newTargetType;
+    private readonly Template _templateCode;
 
-    public AdapterBuilder(Type targetType, Type newTargetType)
+    public AdapterBuilder()
     {
-        _targetType = targetType;
-        _newTargetType = newTargetType;
+        _templateCode = Template.Parse(@"public class {{new_target_type}}Adapter : {{new_target_type}}
+{
+    readonly private {{target_type}} _obj;
+    public {{new_target_type}}Adapter({{target_type}} obj) => _obj = obj;
+{{for property in properties}}
+    public {{property.property_type.name}} {{property.name}}
+    {
+{{if property.can_read}}
+        get => IoC.Resolve<{{property.property_type.name}}>(""Game.Get.Property"", ""{{property.name}}"", _obj);
+{{end}}
+{{if property.can_write}}
+        set => IoC.Resolve<ICommand>(""Game.Set.Property"", ""{{property.name}}"", _obj, value).Execute();
+{{end}}
+    }
+{{end}}
+}");
     }
 
-    public string Build()
+    public void Builder()
     {
-        var templateCode = IoC.Resolve<string>("Template");
 
-        var template = Template.Parse(templateCode);
-
-        var properties = _newTargetType.GetProperties()
-            .Select(property => new
-            {
-                name = property.Name,
-                property_type = new
+        IoC.Resolve<Hwdtech.ICommand>(
+                "IoC.Register",
+                "Game.Adapter.Build",
+                (object[] args) =>
                 {
-                    name = property.PropertyType.Name
-                },
-                can_read = property.CanRead,
-                can_write = property.CanWrite
-            })
-            .ToList();
+                    var newTargetType = (Type)args[0];
+                    var targetType = (Type)args[1];
+                    var properties = newTargetType.GetProperties();
+                    var result = _templateCode.Render(new
+                    {
+                        new_target_type = newTargetType.Name,
+                        target_type = targetType.Name,
+                        properties = properties
 
-        var result = template.Render(new
-        {
-            new_target_type = _newTargetType.Name,
-            target_type = _targetType.Name,
-            properties = properties
-        });
-
-        return result;
+                    });
+                    return result;
+                }
+            ).Execute();
     }
 }

--- a/SpaceBattle.Lib/AdapterBuilder.cs
+++ b/SpaceBattle.Lib/AdapterBuilder.cs
@@ -1,0 +1,43 @@
+using Hwdtech;
+using Scriban;
+
+public class AdapterBuilder
+{
+    private readonly Type _targetType;
+    private readonly Type _newTargetType;
+
+    public AdapterBuilder(Type targetType, Type newTargetType)
+    {
+        _targetType = targetType;
+        _newTargetType = newTargetType;
+    }
+
+    public string Build()
+    {
+        var templateCode = IoC.Resolve<string>("Template");
+
+        var template = Template.Parse(templateCode);
+
+        var properties = _newTargetType.GetProperties()
+            .Select(property => new
+            {
+                name = property.Name,
+                property_type = new
+                {
+                    name = property.PropertyType.Name
+                },
+                can_read = property.CanRead,
+                can_write = property.CanWrite
+            })
+            .ToList();
+
+        var result = template.Render(new
+        {
+            new_target_type = _newTargetType.Name,
+            target_type = _targetType.Name,
+            properties = properties
+        });
+
+        return result;
+    }
+}

--- a/SpaceBattle.Lib/SpaceBattle.Lib.csproj
+++ b/SpaceBattle.Lib/SpaceBattle.Lib.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Hwdtech.IoC" Version="1.0.0" />
     <PackageReference Include="Hwdtech.Ioc.ScopeBasedIoCImplementation" Version="1.0.0" />
+    <PackageReference Include="Scriban" Version="5.12.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
ЛР №10. Генерация адаптеров на “лету”.
Ряд команд, реализующих поведение космического корабля и других игровых объектов, устроены следующим образом:

class SomeCommand: ICommand
{
	private CommandTarget target;

	public SomeCommand(CommandTarget target) => this.target = target;

	public void Execute()
	{
		// реализация команды, которая обращается к объекту target.
	}
} 

Часто получение объекта такой Команды выполняется с помощью следующего кода:

IoC.Resolve<ICommand>(“SomeCommand”, obj);

где obj - объект, для которого будет выполнена создаваемая Команда. При этом стратегия для разрешения зависимости определяется следующим образом.

IoC.Resolve<ICommand>(
“IoC.Register”,
“SomeCommand”,
(Func<object[], object>)(args) => {
	var adapter = IoC.Resolve<SomeCommandTarget>(
“Adapter for SomeCommandTarget”, 
args[0]
);

return new SomeCommand(adapter);
}
).Execute(); 

IoC.Resolve<ICommand>(
“IoC.Register”,
“Adapter for SomeCommandTarget”,
(Func<object[], object>)(args) => return new SomeCommandTargetAdapter(args[0])
}
).Execute(); 

Для разных команд этот код отличается только типами самой команды SomeCommand, SomeCommandTarget и необходимостью написания класса SomeCommandTargetAdapter.
Если бы не класс SomeCommandTargetAdapter, то можно было бы обобщить данную стратегию до одного класса и избавиться от необходимости дублирования данного кода. Если использовать кодогенерацию и рефлексию, то можно этот класс сгенерировать автоматически, используя лишь определение интерфейса SomeCommandTarget.
Задачи:
1. С помощью рефлексии формируется строка - код на С#, являющийся реализацией адаптера
